### PR TITLE
Refactor (ci): Use `ubuntu-20.04` instead of `ubuntu-latest` in github workflow runs

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test-build-hlds:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name != 'pull_request' || github.repository_owner != 'startersclan'
     steps:
     - name: Checkout
@@ -26,7 +26,7 @@ jobs:
         STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
 
   test-update-hlds:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name != 'pull_request' || github.repository_owner != 'startersclan'
     steps:
     - name: Checkout
@@ -40,7 +40,7 @@ jobs:
         STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
 
   test-build-srcds:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
         STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
 
   test-update-srcds:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
Using a clearly defined VM image minimizes breakages in builds that could occur when `:latest` VM images reference newer ones with different build environments.

`ubuntu-latest` presently still references `ubuntu-20.04`, thus no changes should occur in builds.